### PR TITLE
Ajout d'une balance et d'un bol de mélange réaliste

### DIFF
--- a/boulangerie/README.md
+++ b/boulangerie/README.md
@@ -10,6 +10,9 @@ Cet addon ajoute deux métiers de boulangers (traditionnel et industriel) avec u
 ## Fonctionnalités principales
 - Entités de fabrication (sacs de farine, bouteilles d'eau, pâte, plan de travail, fours).
 - Système de mélange, façonnage et cuisson des produits.
+- Balance numérique pour peser les ingrédients.
+- Bol de mélange acceptant sacs de farine et bouteilles d'eau pour créer la pâte.
+- Nouveau produit : pain au chocolat.
 - Interface Derma pour gérer les stocks et les commandes.
 - Persistance simple via fichiers data.
 

--- a/boulangerie/lua/autorun/boulangerie_init.lua
+++ b/boulangerie/lua/autorun/boulangerie_init.lua
@@ -10,7 +10,10 @@ local ENTITIES = {
     "oven_industrial",
     "product_bread",
     "product_croissant",
-    "product_baguette"
+    "product_baguette",
+    "product_painauchocolat",
+    "digital_scale",
+    "mixing_bowl"
 }
 
 for _, ent in ipairs(ENTITIES) do

--- a/boulangerie/lua/entities/digital_scale/cl_init.lua
+++ b/boulangerie/lua/entities/digital_scale/cl_init.lua
@@ -1,0 +1,1 @@
+include("shared.lua")

--- a/boulangerie/lua/entities/digital_scale/init.lua
+++ b/boulangerie/lua/entities/digital_scale/init.lua
@@ -1,0 +1,1 @@
+AddCSLuaFile("shared.lua")

--- a/boulangerie/lua/entities/digital_scale/shared.lua
+++ b/boulangerie/lua/entities/digital_scale/shared.lua
@@ -1,0 +1,24 @@
+include("boulangerie/entities/bakery_base/shared.lua")
+
+ENT.PrintName = "Balance numérique"
+ENT.Model = "models/props_c17/consolebox01a.mdl"
+ENT.Category = "Boulangerie"
+
+if SERVER then
+    function ENT:OnUse(activator)
+        if not IsValid(activator) then return end
+        local mins = self:GetPos() + Vector(-20,-20,0)
+        local maxs = self:GetPos() + Vector(20,20,40)
+        local found = ents.FindInBox(mins, maxs)
+        local mass = 0
+        for _,e in ipairs(found) do
+            if e ~= self then
+                local phys = e:GetPhysicsObject()
+                if IsValid(phys) then
+                    mass = mass + phys:GetMass()
+                end
+            end
+        end
+        activator:ChatPrint("Poids détecté : " .. math.Round(mass,2) .. " kg")
+    end
+end

--- a/boulangerie/lua/entities/mixing_bowl/cl_init.lua
+++ b/boulangerie/lua/entities/mixing_bowl/cl_init.lua
@@ -1,0 +1,1 @@
+include("shared.lua")

--- a/boulangerie/lua/entities/mixing_bowl/init.lua
+++ b/boulangerie/lua/entities/mixing_bowl/init.lua
@@ -1,0 +1,1 @@
+AddCSLuaFile("shared.lua")

--- a/boulangerie/lua/entities/mixing_bowl/shared.lua
+++ b/boulangerie/lua/entities/mixing_bowl/shared.lua
@@ -1,0 +1,40 @@
+include("boulangerie/entities/bakery_base/shared.lua")
+
+ENT.PrintName = "Bol de mélange"
+ENT.Model = "models/props_interiors/pot01a.mdl"
+ENT.Category = "Boulangerie"
+
+if SERVER then
+    function ENT:Initialize()
+        self:SetModel(self.Model)
+        self:PhysicsInit(SOLID_VPHYSICS)
+        self:SetMoveType(MOVETYPE_VPHYSICS)
+        self:SetSolid(SOLID_VPHYSICS)
+        local phys = self:GetPhysicsObject()
+        if phys:IsValid() then phys:Wake() end
+
+        self.flour = 0
+        self.water = 0
+    end
+
+    function ENT:StartTouch(ent)
+        if ent:GetClass() == "flour_bag" then
+            self.flour = self.flour + 1
+            ent:Remove()
+        elseif ent:GetClass() == "water_bottle" then
+            self.water = self.water + 1
+            ent:Remove()
+        end
+        self:CheckMix()
+    end
+
+    function ENT:CheckMix()
+        if self.flour >= 1 and self.water >= 1 then
+            self.flour = self.flour - 1
+            self.water = self.water - 1
+            local dough = ents.Create("dough_ball")
+            dough:SetPos(self:GetPos() + self:GetUp()*20)
+            dough:Spawn()
+        end
+    end
+end

--- a/boulangerie/lua/entities/product_painauchocolat/cl_init.lua
+++ b/boulangerie/lua/entities/product_painauchocolat/cl_init.lua
@@ -1,0 +1,1 @@
+include("shared.lua")

--- a/boulangerie/lua/entities/product_painauchocolat/init.lua
+++ b/boulangerie/lua/entities/product_painauchocolat/init.lua
@@ -1,0 +1,1 @@
+AddCSLuaFile("shared.lua")

--- a/boulangerie/lua/entities/product_painauchocolat/shared.lua
+++ b/boulangerie/lua/entities/product_painauchocolat/shared.lua
@@ -1,0 +1,12 @@
+include("boulangerie/entities/bakery_base/shared.lua")
+
+ENT.PrintName = "Pain au chocolat"
+ENT.Model = "models/props_junk/garbage_bag001a.mdl"
+ENT.Category = "Boulangerie"
+
+function ENT:OnUse(activator)
+    if SERVER then
+        activator:ChatPrint("Délicieux pain au chocolat !")
+        self:Remove()
+    end
+end


### PR DESCRIPTION
## Summary
- ajouter une balance numérique qui calcule la masse des objets posés dessus
- ajouter un bol de mélange consommant sacs de farine et bouteilles d'eau pour créer la pâte
- ajouter le produit `pain au chocolat`
- documenter les nouvelles fonctionnalités

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68411597cca0832da64e828075223bbb